### PR TITLE
Fix comments left on the documentation

### DIFF
--- a/docs/dak.qmd
+++ b/docs/dak.qmd
@@ -1,0 +1,139 @@
+---
+title: "The MamaToto Digital Adaptation Kit (DAK)"
+format: html
+---
+
+
+## Background.
+The Digital Assessment Kit (DAK) is a World Health Organization (WHO) initiative designed to streamline the development and implementation of effective digital health solutions in low- and middle-income countries (LMICs). It provides a standardized framework and a set of tools to guide stakeholders through the process of assessing the feasibility, effectiveness, and scalability of digital health interventions.
+
+The DAK framework emphasizes a user-centered approach, ensuring that digital health solutions address the specific needs and challenges faced by healthcare providers and patients in LMIC settings. By following the DAK guidelines, developers and implementers can increase the likelihood of developing digital health solutions that are sustainable, impactful, and contribute to improved health outcomes.
+
+### Steps.
+#### MamaToto Nairobi: Transforming Maternal Healthcare
+This document outlines the technical requirements for the MamaToto Nairobi project, which leverages technology to improve maternal healthcare. Built on the World Health Organization's DAK framework, it guides the system's design and development.
+
+##### The Challenge:
+
+Despite global efforts, maternal health in Nairobi faces a burden of high mortality and morbidity rates.
+
+##### MamaToto's Solution:
+
+MamaToto tackles this challenge through:
+
+1. Enrollment: Self-registration via WhatsApp and clinics.
+2. ata Tracking: Shared Health Record (SHR) for mobile and clinic access.
+3. Improved Care: Data exchange through a Health Information Exchange (HIE).
+
+##### Benefits:
+
+1. Increased antenatal visit attendance.
+2. Optimized resource allocation.
+3. Improved program evaluation (e.g., MomCare).
+
+##### Next Steps:
+
+This document details the project's specifics using the DAK framework.
+
+### Core Data Elements in MamaToto
+The MamaToto project leverages a comprehensive set of data elements to track and manage the health information of pregnant women.  These elements are captured at various points, including enrollment, antenatal visits, and data exchange.
+
+A dedicated "Data Dictionary" appendix within this guide will provide detailed definitions, data types, and how each element is used.
+
+Here's a categorized overview of some core data elements you'll find in the Data Dictionary:
+
+1. Patient Sociodemographics: Name, date of birth, address, phone number.
+2. Pregnancy Information: Estimated due date, gestational age, pregnancy history.
+3. Antenatal Visit Data: Blood pressure, weight, fetal development observations.
+4. Referral & Service Utilization: Referrals to specialists or additional services.
+5. Immunization Records: Tracking of vaccinations received during pregnancy.
+6. Laboratory Test Results: Integration of relevant lab test results.
+
+#### Sample Business Processes and Data Elements:
+
+The DAK also outlines data elements linked to specific business processes within MamaToto. Here are a few examples for illustration:
+
+1. Create Beneficiary: This process captures basic information like name, date of birth, and contact details (MMT.A.DE1 - MMT.A.DE9).
+2. Add Beneficiary to Policy: This process includes details beyond basic demographics, such as beneficiary type, occupation, and insurance membership (MMT.B.DE5 - MMT.B.DE23).
+3. Download Bulk Enrollment Status: This process manages uploading beneficiary data in bulk. It tracks the reference ID, processing status, and error details (MMT.D.DE01 - MMT.D.DE06).
+4. Validate Policy: This process ensures a policy is valid by checking factors like the number of beneficiaries (MMT.E.DE01) and integration errors (MMT.E.DE02).
+
+**Note:** This is not an exhaustive list, and the specific data elements used may  change based on evolving needs.
+
+### Functional and Non-Functional Requirements 
+This section summarizes the key functional and non-functional requirements for the MamaToto system, ensuring it meets user needs and operates effectively.
+
+#### Functional Requirements:
+
+1. Interoperability Layer (IOL): Acts as a central hub for HIE services, enabling data exchange and message routing between healthcare providers. It also facilitates complex transactions, error management, and secure communication.
+2. Shared Health Record (SHR): Serves as a repository for patient clinical data, offering functionalities for data storage, retrieval, querying, and export. It prioritizes data integrity through versioning and audit logs.
+
+#### Non-Functional Requirements:
+
+1. Performance: The system should deliver minimal response times and handle asynchronous processes efficiently.
+2. Security: Robust security measures are essential, including user authentication, password encryption, data access controls, and audit trails.
+3. Usability: An intuitive user interface is crucial for users with varying technical skills.
+4. Reliability: Regular system testing ensures accuracy, reliability, and performance under high data loads.
+
+***These are general highlights, and specific requirements will be further elaborated upon in the project documentation.***
+
+### Overall Description
+MamaToto is a cutting-edge project transforming maternal healthcare in Nairobi, Kenya by leveraging advanced technology. Built on the robust DHIS2 platform and embracing modern tools, it aims to revolutionize data management and analysis for improved maternal health outcomes.
+
+#### Key Focus Areas:
+
+1. Data Quality: MamaToto tackles inaccurate or incomplete data through innovative solutions, ensuring reliable information for informed decision-making.
+2. Reporting Efficiency: By streamlining processes and automating tasks, MamaToto empowers stakeholders to meet reporting deadlines consistently.
+3. Interoperability: Designed with an open approach, MamaToto seamlessly interacts with other health information systems, facilitating data exchange and eliminating silos.
+4. dvanced Analytics: Modern tools enable in-depth analysis of maternal health data, providing valuable insights for targeted interventions and resource allocation.
+5. User Empowerment: MamaToto prioritizes user needs, offering intuitive interfaces and comprehensive support, making the system accessible and efficient for all stakeholders.
+
+#### Overall Impact:
+
+Through its multifaceted approach, MamaToto aspires to:
+
+1. Enhance the quality of care for pregnant women and mothers.
+2. Strengthen decision-making with accurate and insightful data.
+3. Optimize resource allocation for maximum impact.
+4. Improve overall efficiency and effectiveness of maternal healthcare services.
+
+#### Product Features
+##### Client Management
+
+1. Client Registration: Initial registration of new patients, including demographics, contact details, and other relevant personal data. Duplicate record flagging and merging capabilities.
+2. Client Search: Enables healthcare providers to quickly access patient demographic records.
+
+##### Clinical Data Management
+
+1. Clinical Information Capture: Capture and document clinical information obtained during antenatal visits, including medical history, symptoms, diagnoses, treatment plans, medications, lab results, imaging reports, and other relevant data.
+2. Clinical Information Retrieval: Access patient data from the SHR when needed for patient care, decision-making, and/or analytics.
+
+#### Reporting & Analytics
+
+The SHR provides mechanisms for reporting and generating reports to support decision-making within and outside health facilities.
+
+##### Data Integration
+
+Data Import & Export: Ability to extract data from the SHR and ingest data in bulk into the SHR or another system.
+
+##### Operating Environment
+**Technical Specifications**
+
+**Backend Services**
+1. Hardware Platform: Standard desktop computers, laptops, and mobile devices.
+2. Operating System: Windows, macOS, Linux.
+3. Network Connectivity: Internet connection required for backend services.
+
+**User-facing Services**
+1. ardware Platform: Standard desktop computers, laptops, and mobile devices.
+2. Operating System: Windows, macOS, Linux, iOS, and Android.
+3. Web Browsers: Chrome, Firefox, Safari, and Edge.
+4. Network Connectivity: Internet connection required for backend services.
+
+##### User Documentation
+
+Well-detailed system documentation will be provided to guide administrators and users on the system architecture.
+
+##### Assumptions and Dependencies
+1. Cloud-based deployment environment.
+2. Applications accessing the service require a constant internet connection.

--- a/docs/getting_started.qmd
+++ b/docs/getting_started.qmd
@@ -6,12 +6,12 @@ format: html
 
 ##### Pre-requisites.
 
-1. Docker - Instructions on how to install Docker can be found on the Docker website
+1. Docker - Instructions on how to install Docker can be found on the [Docker website](https://www.docker.com/get-started/)
 2. Instant OpenHIE v2 CLI - Installation instructions [here](https://jembi.gitbook.io/instant-v2/getting-started/quick-start): 
 
 ##### Clone the repository
 
-`git clone https://github.com/IntelliSOFT-Consulting/MamaToto-HIE.git`
+`git clone https://github.com/PharmAccess/hdc-documentation.git`
 
 
 ##### Configuration.

--- a/docs/iol/challenges/fhir_web.qmd
+++ b/docs/iol/challenges/fhir_web.qmd
@@ -12,6 +12,12 @@ Setting up FHIR Web Version 3.1.3 is quite challenging given the limited documen
 
 #### Challenges
 1. Lack of documentation.
-   The project is not very well documented therefore
+While FHIR Web might have some general documentation, it often lacks specific details on how to configure it to work seamlessly with a FHIR server. This is especially true if you need FHIR Web to interact with a FHIR server that requires custom configurations beyond the defaults.
+
+For instance, you might encounter challenges understanding how to:
+
+   1. onfigure FHIR Web to point to your specific FHIR server instance.
+   2. Set up authentication between FHIR Web and the FHIR server.
+   3. Customize FHIR Web's behavior based on functionalities offered by your FHIR server.
 
 2. Configuration.

--- a/docs/iol/challenges/keycloak_intergration.qmd
+++ b/docs/iol/challenges/keycloak_intergration.qmd
@@ -6,7 +6,13 @@ format: html
 
 ## Background
 
-The OpenHIM offers a few authentication mechanisms to verify client interactions with the OpenHIM Core. These mechanisms are JWT Tokens, Custom Tokens, Mutual TLS and Basic Auth. These Authentication mechanisms can be configured via JSON config files (see overview for more) or environment variables. The configured auth mechanisms will be displayed in the Client details section of the OpenHIM Console
+The OpenHIM offers a few authentication mechanisms to verify client interactions with the OpenHIM Core. These mechanisms are 
+1. JWT Tokens
+2. Custom Tokens
+3. Mutual TLS 
+4. Basic Auth. 
+
+These Authentication mechanisms can be configured via JSON config files (see overview for more) or environment variables. The configured auth mechanisms will be displayed in the Client details section of the OpenHIM Console.
 
 One of the useful features of OpenHIM is ability to use your own auth provides to configure.
 However, this is not a very straight-forward process as there lacks any documentation online on how to set this up or how to troubleshoot.

--- a/docs/iol/instant-v2/instant_v2.qmd
+++ b/docs/iol/instant-v2/instant_v2.qmd
@@ -14,11 +14,16 @@ All HDC HIE components are packaged as Instant v2 HIE Components.
 
 List of packages:
 
-1. identity-access-manager-keycloak
-2. reverse-proxy-nginx
-3. mamatoto-datastore-hapi-fhir
-4. mamatoto-interoperability-layer-openhim
-5. mamatoto-openhim-mediators
+1. identity-access-manager-keycloak : 
+    This component provides an identity and access management (IAM) solution using Keycloak. It authenticates users and authorizes access to the HIE system.
+2. reverse-proxy-nginx : 
+    This component acts as a reverse proxy, routing incoming traffic to the appropriate backend services within the HIE system based on URL patterns.
+3. mamatoto-datastore-hapi-fhir : 
+    This component stores and manages health data in a FHIR (Fast Healthcare Interoperability Resources) format. It uses the HAPI FHIR server implementation for data persistence and retrieval.
+4. mamatoto-interoperability-layer-openhim : 
+    This component acts as an interoperability layer using OpenHIM. It facilitates data exchange between MamaToto HIE and other disparate health information systems.
+5. mamatoto-openhim-mediators : 
+    These are custom OpenHIM mediators developed specifically for MamaToto HIE. They translate and transform data between different formats to ensure smooth information exchange.
 
 
 Sample `config.yml` shown below:
@@ -56,3 +61,15 @@ profiles:
     only: true
 
 ```
+
+The `config.yml` file is a configuration file used by Instant HIE v2 to define your deployment settings. It specifies various options like the project name, Docker image to use, and which Instant HIE packages to include.
+
+Here's how it's used:
+
+  1. Create the config.yml file: Use a text editor to create a file named config.yml in your project directory.
+  2. Edit the configuration options: Paste the content you want into the file, replacing placeholders with your specific values. Refer to the Instant HIE v2 documentation for a detailed explanation of each configuration option.
+  3. Use the config.yml file: When using the Instant HIE v2 CLI commands (e.g., instant package up), these commands will reference the config.yml file to determine your deployment configuration.
+
+The provided `config.yml` example demonstrates how to configure an Instant HIE v2 deployment profile for MamaToto HIE. It includes references to the aforementioned components.
+
+By leveraging Instant HIE v2, MamaToto HIE benefits from a simplified deployment process, easier management of its components, and potential scalability for handling increased data exchange needs.


### PR DESCRIPTION
Hello Brian, please help review this.

I've worked on the comments below:

1.  docs/getting_started.qmd

- [ ] add link to docker website
- [ ] should refer to pharmaccess instance probably a fork of this or repo is transferred

2. docs/iol/instant-v2/instant_v2.qmd

- [ ] if including sample file describe what it's used for and how to implement
- [ ] it would be nice to describe a short summary of what each component does and include fhirweb too

3. docs/iol/challenges/fhir_web.qmd

- [ ] be specific in the description of the challenge, i.e specify that fhirweb needed custom config on fhirserver for it to work.

4. docs/iol/challenges/keycloak_intergration.qmd

- [ ] add mechanism as bullets for easy reading
- [ ] add link to overview page
